### PR TITLE
Fix GitHub links and badges for Pico.css and Simple.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ This is a list of classless CSS themes and frameworks.  "Classless" means a styl
 
 Pico.css also has a class-light version, which is its main version.
 
-* [Repository](https://github.com/https://github.com/picocss/pico) ![GitHub stars](https://img.shields.io/github/stars/https://github.com/picocss/pico?style=flat-square) ![GitHub contributors](https://img.shields.io/github/contributors-anon/https://github.com/picocss/pico?style=flat-square) ![Last commit](https://img.shields.io/github/last-commit/https://github.com/picocss/pico?style=flat-square) ![GitHub open issues](https://img.shields.io/github/issues-raw/https://github.com/picocss/pico?style=flat-square) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/https://github.com/picocss/pico?style=flat-square)
+* [Repository](https://github.com/picocss/pico) ![GitHub stars](https://img.shields.io/github/stars/picocss/pico?style=flat-square) ![GitHub contributors](https://img.shields.io/github/contributors-anon/picocss/pico?style=flat-square) ![Last commit](https://img.shields.io/github/last-commit/picocss/pico?style=flat-square) ![GitHub open issues](https://img.shields.io/github/issues-raw/picocss/pico?style=flat-square) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/picocss/pico?style=flat-square)
 * [Demo](https://picocss.com/examples/preview/)
 
 [![pico-css.png](thumbnail/pico-css.png)](screenshot/pico-css.png)
@@ -251,7 +251,7 @@ Pico.css also has a class-light version, which is its main version.
 
 ### Simple.css
 
-* [Repository](https://github.com/https://github.com/kevquirk/simple.css) ![GitHub stars](https://img.shields.io/github/stars/https://github.com/kevquirk/simple.css?style=flat-square) ![GitHub contributors](https://img.shields.io/github/contributors-anon/https://github.com/kevquirk/simple.css?style=flat-square) ![Last commit](https://img.shields.io/github/last-commit/https://github.com/kevquirk/simple.css?style=flat-square) ![GitHub open issues](https://img.shields.io/github/issues-raw/https://github.com/kevquirk/simple.css?style=flat-square) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/https://github.com/kevquirk/simple.css?style=flat-square)
+* [Repository](https://github.com/kevquirk/simple.css) ![GitHub stars](https://img.shields.io/github/stars/kevquirk/simple.css?style=flat-square) ![GitHub contributors](https://img.shields.io/github/contributors-anon/kevquirk/simple.css?style=flat-square) ![Last commit](https://img.shields.io/github/last-commit/kevquirk/simple.css?style=flat-square) ![GitHub open issues](https://img.shields.io/github/issues-raw/kevquirk/simple.css?style=flat-square) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/kevquirk/simple.css?style=flat-square)
 * [Demo](https://simplecss.org/demo)
 
 [![simple-css.png](thumbnail/simple-css.png)](screenshot/simple-css.png)


### PR DESCRIPTION
This pull request fixes the GitHub links and badges for Pico.css and Simple.css, as both have a duplicated 'https://github.com/' in their links.